### PR TITLE
Hide Share button, because sharing is (was already) broken, according to @rullzer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -166,6 +166,7 @@
 	float: left;
 	background-position: 5px center;
 	padding-left: 24px;
+	display: none;
 }
 
 #mainContainer{


### PR DESCRIPTION
code is still there and can be fixed by a volunteer
